### PR TITLE
Add attachments to mail helper

### DIFF
--- a/loutilities/flask_helpers/mailer.py
+++ b/loutilities/flask_helpers/mailer.py
@@ -7,11 +7,12 @@ mailer - send email
 # pypi
 from flask import current_app
 from flask_mail import Message
+import mimetypes
 
 debug = False
 
 #----------------------------------------------------------------------
-def sendmail(subject, fromaddr, toaddr, html, text='', ccaddr=None, replytoaddr=None):
+def sendmail(subject, fromaddr, toaddr, html, text='', ccaddr=None, replytoaddr=None, attachments=[]):
 #----------------------------------------------------------------------
     '''
     send mail
@@ -23,6 +24,7 @@ def sendmail(subject, fromaddr, toaddr, html, text='', ccaddr=None, replytoaddr=
     :param text: optional text alternative to send
     :param ccaddr: optional cc address to use, may be list of addresses or comma separated
     :param replytoaddr: optional reply_to address to use, may be list of addresses or comma separated
+    :param attachments: optional attachments to include, list of Dict containing {'filename': 'text-name', 'data': 'file-data'}
     :returns: response from flask_mail.send
     '''
     stubbed = current_app.config.get('MAIL_SUPPRESS_SEND', current_app.config.get('TESTING', False))
@@ -42,6 +44,10 @@ def sendmail(subject, fromaddr, toaddr, html, text='', ccaddr=None, replytoaddr=
         body=text,
     )
 
+    for attachment in attachments:
+        if all(k in attachment for k in ("filename","data")):
+            message.attach(attachment['filename'], mimetypes.guess_type(attachment['filename'])[0],attachment['data']);
+ 
     mail.send(message)
 
     if debug: current_app.logger.debug('sendmail(): message.html={}'.format(message.html))

--- a/loutilities/flask_helpers/mailer.py
+++ b/loutilities/flask_helpers/mailer.py
@@ -7,7 +7,7 @@ mailer - send email
 # pypi
 from flask import current_app
 from flask_mail import Message
-import mimetypes
+from mimetypes import guess_type
 
 debug = False
 
@@ -46,7 +46,7 @@ def sendmail(subject, fromaddr, toaddr, html, text='', ccaddr=None, replytoaddr=
 
     for attachment in attachments:
         if all(k in attachment for k in ("filename","data")):
-            message.attach(attachment['filename'], mimetypes.guess_type(attachment['filename'])[0],attachment['data']);
+            message.attach(attachment['filename'], guess_type(attachment['filename'])[0],attachment['data']);
  
     mail.send(message)
 


### PR DESCRIPTION
Add parameter to include attachments with emails.  The additional parameter is a list of dicts containing the filename and file contents.  File contents are passed instead of file path to give the flexibility to generate files in memory without disk. 

Example call:  

```python
f = open("test2.json", "r")
varWithFileContents = '' # raw file contents

attach = []
attach.append({'filename': 'test.json, 'data': varWithFileContents })
attach.append({'filename': 'test2.json, 'data': f.read() })

sendmail('Test Subject', 'example@example.com', 'example@example.com', 'body', text='body', ccaddr=None, replytoaddr=None, attachments=attach):
```
